### PR TITLE
Move ValueTupleExtensions into Extensions namespace

### DIFF
--- a/Assets/Scripts/Drawing/Shapes/Diamond.cs
+++ b/Assets/Scripts/Drawing/Shapes/Diamond.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using PAC.DataStructures;
+using PAC.Extensions;
 using PAC.Shapes.Interfaces;
 
 namespace PAC.Shapes

--- a/Assets/Scripts/Extensions/ValueTuple/ValueTupleExtensions.cs
+++ b/Assets/Scripts/Extensions/ValueTuple/ValueTupleExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace PAC
+namespace PAC.Extensions
 {
     public static class ValueTupleExtensions
     {


### PR DESCRIPTION
# Summary

Moves `ValueTupleExtensions` into the `PAC.Extensions` namespace.