### PR TITLE
Snap to perfect line

### DIFF
--- a/Assets/Scripts/Data Structures/Plane2D.cs
+++ b/Assets/Scripts/Data Structures/Plane2D.cs
@@ -1,0 +1,115 @@
+using System;
+
+using PAC.Exceptions;
+
+namespace PAC.DataStructures
+{
+    /// <summary>
+    /// Provides ways to deal with the 2D plane.
+    /// </summary>
+    public static class Plane2D
+    {
+        /// <summary>
+        /// One of 8 regions of the 2D plane.
+        /// </summary>
+        [Flags]
+        public enum Octant : byte
+        {
+            /// <summary>
+            /// The north-northeast octant.
+            /// </summary>
+            NorthNortheast = 1,
+            /// <summary>
+            /// The east-northeast octant.
+            /// </summary>
+            EastNortheast = 1 << 1,
+            /// <summary>
+            /// The east-southeast octant.
+            /// </summary>
+            EastSoutheast = 1 << 2,
+            /// <summary>
+            /// The south-southeast octant.
+            /// </summary>
+            SouthSoutheast = 1 << 3,
+            /// <summary>
+            /// The south-southwest octant.
+            /// </summary>
+            SouthSouthwest = 1 << 4,
+            /// <summary>
+            /// The west-southwest octant.
+            /// </summary>
+            WestSouthwest = 1 << 5,
+            /// <summary>
+            /// The west-northwest octant.
+            /// </summary>
+            WestNorthwest = 1 << 6,
+            /// <summary>
+            /// The north-northwest octant.
+            /// </summary>
+            NorthNorthwest = 1 << 7,
+        }
+
+        /// <summary>
+        /// Returns which <see cref="Octant"/>(s) the given point is in.
+        /// </summary>
+        /// <remarks>
+        /// For this method, <see cref="Octant"/>s include their boundaries and hence overlap. For example, <see cref="Octant.NorthNortheast"/> and <see cref="Octant.NorthNorthwest"/> both
+        /// contain the half-line <c>{ (0, y) : y >= 0 }</c>. In this case, the flag nature of <see cref="Octant"/> is used to return multiple values.
+        /// </remarks>
+        public static Octant GetOctant(IntVector2 point)
+        {
+            Octant octant = 0;
+
+            if (point.y >= point.x)
+            {
+                if (point.x >= 0)
+                {
+                    octant |= Octant.NorthNortheast;
+                }
+                if (point.y <= 0)
+                {
+                    octant |= Octant.WestSouthwest;
+                }
+            }
+            if (point.y <= point.x)
+            {
+                if (point.x <= 0)
+                {
+                    octant |= Octant.SouthSouthwest;
+                }
+                if (point.y >= 0)
+                {
+                    octant |= Octant.EastNortheast;
+                }
+            }
+            if (point.y >= -point.x)
+            {
+                if (point.x <= 0)
+                {
+                    octant |= Octant.NorthNorthwest;
+                }
+                if (point.y <= 0)
+                {
+                    octant |= Octant.EastSoutheast;
+                }
+            }
+            if (point.y <= -point.x)
+            {
+                if (point.x >= 0)
+                {
+                    octant |= Octant.SouthSoutheast;
+                }
+                if (point.y >= 0)
+                {
+                    octant |= Octant.WestNorthwest;
+                }
+            }
+
+            if (octant == 0)
+            {
+                throw new UnreachableException();
+            }
+            return octant;
+        }
+    }
+}

--- a/Assets/Scripts/Data Structures/Plane2D.cs.meta
+++ b/Assets/Scripts/Data Structures/Plane2D.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80b5c551cce39174f98b4caddd3e216b

--- a/Assets/Scripts/Drawing/DrawingArea.cs
+++ b/Assets/Scripts/Drawing/DrawingArea.cs
@@ -758,7 +758,15 @@ namespace PAC.Drawing
             }
             else if (tool == Tool.Line)
             {
-                if (leftClickedOn) { PreviewShape(new Line(mouseDragPoints[0], pixel), colour); }
+                if (leftClickedOn)
+                {
+                    IntVector2 end = pixel;
+                    if (holdingCtrl)
+                    {
+                        end = CoordSnapping.SnapToPerfectLine(mouseDragPoints[0], end);
+                    }
+                    PreviewShape(new Line(mouseDragPoints[0], end), colour);
+                }
             }
             else if (tool == Tool.Shape && (leftClickedOn || rightClickedOn))
             {
@@ -855,7 +863,12 @@ namespace PAC.Drawing
         {
             if (tool == Tool.Line && leftClickedOn)
             {
-                Tools.UseShape(file, layer, frame, new Line(mouseDragPoints[0], pixel), colour);
+                IntVector2 end = pixel;
+                if (holdingCtrl)
+                {
+                    end = CoordSnapping.SnapToPerfectLine(mouseDragPoints[0], end);
+                }
+                Tools.UseShape(file, layer, frame, new Line(mouseDragPoints[0], end), colour);
                 UpdateDrawing();
             }
             else if (tool == Tool.Shape && (leftClickedOn || rightClickedOn))

--- a/Assets/Scripts/Maths/MathExtensions.cs
+++ b/Assets/Scripts/Maths/MathExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 using UnityEngine;
@@ -374,5 +375,32 @@ namespace PAC.Maths
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Square(this float n) => n * n;
+
+        /// <summary>
+        /// Returns the minimum element.
+        /// </summary>
+        /// <exception cref="ArgumentException"><paramref name="elements"/> is empty.</exception>
+        public static int Min(params int[] elements)
+        {
+            if (elements.Length == 0)
+            {
+                throw new ArgumentException($"{nameof(elements)} must not be empty.");
+            }
+
+            return elements.Min();
+        }
+        /// <summary>
+        /// Returns the maximum element.
+        /// </summary>
+        /// <exception cref="ArgumentException"><paramref name="elements"/> is empty.</exception>
+        public static int Max(params int[] elements)
+        {
+            if (elements.Length == 0)
+            {
+                throw new ArgumentException($"{nameof(elements)} must not be empty.");
+            }
+
+            return elements.Max();
+        }
     }
 }

--- a/Assets/Tests/Data Structures/Plane2D_Tests.cs
+++ b/Assets/Tests/Data Structures/Plane2D_Tests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+
+using PAC.DataStructures;
+
+namespace PAC.Tests.DataStructures
+{
+    public static class Plane2D_Tests
+    {
+        /// <summary>
+        /// Tests <see cref="Plane2D.GetOctant(IntVector2)"/>.
+        /// </summary>
+        [Test]
+        public static void GetOctant()
+        {
+            Assert.AreEqual(Plane2D.Octant.NorthNortheast, Plane2D.GetOctant((1, 2)));
+            Assert.AreEqual(Plane2D.Octant.EastNortheast, Plane2D.GetOctant((3, 2)));
+            Assert.AreEqual(Plane2D.Octant.EastSoutheast, Plane2D.GetOctant((5, -3)));
+            Assert.AreEqual(Plane2D.Octant.SouthSoutheast, Plane2D.GetOctant((2, -7)));
+            Assert.AreEqual(Plane2D.Octant.SouthSouthwest, Plane2D.GetOctant((-3, -4)));
+            Assert.AreEqual(Plane2D.Octant.WestSouthwest, Plane2D.GetOctant((-100, -43)));
+            Assert.AreEqual(Plane2D.Octant.WestNorthwest, Plane2D.GetOctant((-2, 1)));
+            Assert.AreEqual(Plane2D.Octant.NorthNorthwest, Plane2D.GetOctant((-5, 200)));
+
+            Assert.AreEqual(Plane2D.Octant.NorthNortheast | Plane2D.Octant.EastNortheast, Plane2D.GetOctant((1, 1)));
+            Assert.AreEqual(Plane2D.Octant.EastNortheast | Plane2D.Octant.EastSoutheast, Plane2D.GetOctant((2, 0)));
+            Assert.AreEqual(Plane2D.Octant.EastSoutheast | Plane2D.Octant.SouthSoutheast, Plane2D.GetOctant((3, -3)));
+            Assert.AreEqual(Plane2D.Octant.SouthSoutheast | Plane2D.Octant.SouthSouthwest, Plane2D.GetOctant((0, -1)));
+            Assert.AreEqual(Plane2D.Octant.SouthSouthwest | Plane2D.Octant.WestSouthwest, Plane2D.GetOctant((-2, -2)));
+            Assert.AreEqual(Plane2D.Octant.WestSouthwest | Plane2D.Octant.WestNorthwest, Plane2D.GetOctant((-10, 0)));
+            Assert.AreEqual(Plane2D.Octant.WestNorthwest | Plane2D.Octant.NorthNorthwest, Plane2D.GetOctant((-45, 45)));
+            Assert.AreEqual(Plane2D.Octant.NorthNorthwest | Plane2D.Octant.NorthNortheast, Plane2D.GetOctant((0, 4)));
+
+            const Plane2D.Octant AllOctants = Plane2D.Octant.NorthNortheast | Plane2D.Octant.EastNortheast | Plane2D.Octant.EastSoutheast | Plane2D.Octant.SouthSoutheast
+                | Plane2D.Octant.SouthSouthwest | Plane2D.Octant.WestSouthwest | Plane2D.Octant.WestNorthwest | Plane2D.Octant.NorthNorthwest;
+
+            Assert.AreEqual(AllOctants, Plane2D.GetOctant((0, 0)));
+        }
+    }
+}

--- a/Assets/Tests/Data Structures/Plane2D_Tests.cs.meta
+++ b/Assets/Tests/Data Structures/Plane2D_Tests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba70d64cc0fe1d44f82eabf3066e7626

--- a/Assets/Tests/Drawing/CoordSnapping_Tests.cs
+++ b/Assets/Tests/Drawing/CoordSnapping_Tests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 
 using PAC.DataStructures;
 using PAC.Drawing;
+using PAC.Extensions;
+using PAC.Shapes;
 
 namespace PAC.Tests.Drawing
 {
@@ -50,6 +52,141 @@ namespace PAC.Tests.Drawing
                     {
                         Assert.AreEqual(IntVector2.Sign(movablePoint - fixedPoint), IntVector2.Sign(snappedPoint - fixedPoint), $"Failed with {fixedPoint} and {movablePoint}.");
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="CoordSnapping.SnapToPerfectLine(IntVector2, IntVector2, int)"/> does indeed form a perfect <see cref="Line"/>.
+        /// </summary>
+        [Test]
+        [Category("Drawing")]
+        public void SnapToPerfectLine_FormsPerfectLine()
+        {
+            Random random = new Random(0);
+            IntRect testRegion = new IntRect((-20, -20), (20, 20));
+            for (int i = 0; i < 10_000; i++)
+            {
+                IntVector2 fixedPoint = testRegion.RandomPoint(random);
+                IntVector2 movablePoint = testRegion.RandomPoint(random);
+
+                IntVector2 snappedPoint = CoordSnapping.SnapToPerfectLine(fixedPoint, movablePoint);
+                Line snappedLine = new Line(fixedPoint, snappedPoint);
+
+                Assert.True(snappedLine.isPerfect, $"Failed with {nameof(fixedPoint)} = {fixedPoint} and {nameof(movablePoint)} = {movablePoint}.");
+            }
+        }
+
+        /// <summary>
+        /// Tests that, for <see cref="CoordSnapping.SnapToPerfectLine(IntVector2, IntVector2, int)"/>, the quadrant (relative to the horizontal/vertical axes through the fixed input point) that the
+        /// snapped point lies in matches that of the movable input point (including potentially lying on the axes).
+        /// </summary>
+        [Test]
+        [Category("Drawing")]
+        public void SnapToPerfectLine_PreservesQuadrant()
+        {
+            Random random = new Random(0);
+            IntRect testRegion = new IntRect((-20, -20), (20, 20));
+            for (int i = 0; i < 10_000; i++)
+            {
+                IntVector2 fixedPoint = testRegion.RandomPoint(random);
+                IntVector2 movablePoint = testRegion.RandomPoint(random);
+
+                IntVector2 snappedPoint = CoordSnapping.SnapToPerfectLine(fixedPoint, movablePoint);
+
+                IntVector2 originalSign = (movablePoint - fixedPoint).sign;
+                IntVector2 snappedSign = (snappedPoint - fixedPoint).sign;
+
+                Assert.True(
+                        originalSign.x == snappedSign.x || snappedSign.x == 0,
+                        $"Failed with {nameof(fixedPoint)} = {fixedPoint} and {nameof(movablePoint)} = {movablePoint}."
+                        );
+                Assert.True(
+                        originalSign.y == snappedSign.y || snappedSign.y == 0,
+                        $"Failed with {nameof(fixedPoint)} = {fixedPoint} and {nameof(movablePoint)} = {movablePoint}."
+                        );
+            }
+        }
+
+        /// <summary>
+        /// Tests that translating the input points of <see cref="CoordSnapping.SnapToPerfectLine(IntVector2, IntVector2, int)"/> (by the same amount), translates the snapped point by the same
+        /// amount.
+        /// </summary>
+        [Test]
+        [Category("Drawing")]
+        public void SnapToPerfectLine_TranslatingInputsTranslatesOutput()
+        {
+            Random random = new Random(0);
+            IntRect testRegion = new IntRect((-20, -20), (20, 20));
+            for (int i = 0; i < 10_000; i++)
+            {
+                IntVector2 fixedPoint = testRegion.RandomPoint(random);
+                IntVector2 movablePoint = testRegion.RandomPoint(random);
+
+                IntVector2 snappedPoint = CoordSnapping.SnapToPerfectLine(fixedPoint, movablePoint);
+
+                IntVector2 translation = testRegion.RandomPoint(random);
+
+                IntVector2 snappedPointTranslatedInputs = CoordSnapping.SnapToPerfectLine(fixedPoint + translation, movablePoint + translation);
+
+                Assert.AreEqual(
+                    snappedPoint + translation, snappedPointTranslatedInputs,
+                    $"Failed with {nameof(fixedPoint)} = {fixedPoint}, {nameof(movablePoint)} = {movablePoint} and {nameof(translation)} = {translation}."
+                    );
+            }
+        }
+        /// <summary>
+        /// Tests that rotating the input points of <see cref="CoordSnapping.SnapToPerfectLine(IntVector2, IntVector2, int)"/> (by the same angle), rotates the snapped point by the same angle.
+        /// </summary>
+        [Test]
+        [Category("Drawing")]
+        public void SnapToPerfectLine_RotatingInputsRotatesOutput()
+        {
+            Random random = new Random(0);
+            IntRect testRegion = new IntRect((-20, -20), (20, 20));
+            for (int i = 0; i < 10_000; i++)
+            {
+                IntVector2 fixedPoint = testRegion.RandomPoint(random);
+                IntVector2 movablePoint = testRegion.RandomPoint(random);
+
+                IntVector2 snappedPoint = CoordSnapping.SnapToPerfectLine(fixedPoint, movablePoint);
+
+                foreach (RotationAngle angle in TypeExtensions.GetValues<RotationAngle>())
+                {
+                    IntVector2 snappedPointRotatedInputs = CoordSnapping.SnapToPerfectLine(fixedPoint.Rotate(angle), movablePoint.Rotate(angle));
+
+                    Assert.AreEqual(
+                        snappedPoint.Rotate(angle), snappedPointRotatedInputs,
+                        $"Failed with {nameof(fixedPoint)} = {fixedPoint}, {nameof(movablePoint)} = {movablePoint} and {nameof(angle)} = {angle}."
+                        );
+                }
+            }
+        }
+        /// <summary>
+        /// Tests that reflecting the input points of <see cref="CoordSnapping.SnapToPerfectLine(IntVector2, IntVector2, int)"/> (across the same axis), reflects the snapped point across the
+        /// same axis.
+        /// </summary>
+        [Test]
+        [Category("Drawing")]
+        public void SnapToPerfectLine_ReflectingInputsReflectsOutput()
+        {
+            Random random = new Random(0);
+            IntRect testRegion = new IntRect((-20, -20), (20, 20));
+            for (int i = 0; i < 10_000; i++)
+            {
+                IntVector2 fixedPoint = testRegion.RandomPoint(random);
+                IntVector2 movablePoint = testRegion.RandomPoint(random);
+
+                IntVector2 snappedPoint = CoordSnapping.SnapToPerfectLine(fixedPoint, movablePoint);
+
+                foreach (FlipAxis axis in TypeExtensions.GetValues<FlipAxis>())
+                {
+                    IntVector2 snappedPointReflectedInputs = CoordSnapping.SnapToPerfectLine(fixedPoint.Flip(axis), movablePoint.Flip(axis));
+
+                    Assert.AreEqual(
+                        snappedPoint.Flip(axis), snappedPointReflectedInputs,
+                        $"Failed with {nameof(fixedPoint)} = {fixedPoint}, {nameof(movablePoint)} = {movablePoint} and {nameof(axis)} = {axis}."
+                        );
                 }
             }
         }


### PR DESCRIPTION
# Summary

Adds the ability to hold Ctrl when drawing a line to snap it to the closest perfect line ('perfect' meaning made up of blocks of a constant size).

# Tickets

Completes PAC-290.