### PR TITLE
Improve colour comments

### DIFF
--- a/Assets/Scripts/Colour/HSL.cs
+++ b/Assets/Scripts/Colour/HSL.cs
@@ -52,7 +52,7 @@ namespace PAC.Colour
 
         #region Conversion
         /// <summary>
-        /// Returns an <see cref="HSL"/> with the same HSL values and with the given alpha.
+        /// Returns an <see cref="HSLA"/> with the same HSL values and with the given alpha.
         /// </summary>
         public HSLA WithAlpha(float alpha) => new HSLA(h, s, l, alpha);
 

--- a/Assets/Scripts/Colour/HSL.cs
+++ b/Assets/Scripts/Colour/HSL.cs
@@ -9,6 +9,7 @@ namespace PAC.Colour
     /// <summary>
     /// A colour in HSL (Hue, Saturation, Lightness) form with no alpha component.
     /// </summary>
+    /// <seealso cref="HSLA"/>
     public readonly struct HSL : IEquatable<HSL>
     {
         #region Fields

--- a/Assets/Scripts/Colour/HSLA.cs
+++ b/Assets/Scripts/Colour/HSLA.cs
@@ -9,6 +9,7 @@ namespace PAC.Colour
     /// <summary>
     /// A colour in HSL (Hue, Saturation, Lightness) form with an alpha component.
     /// </summary>
+    /// <seealso cref="HSL"/>
     public readonly struct HSLA : IEquatable<HSLA>
     {
         #region Fields

--- a/Assets/Scripts/Colour/HSV.cs
+++ b/Assets/Scripts/Colour/HSV.cs
@@ -9,6 +9,7 @@ namespace PAC.Colour
     /// <summary>
     /// A colour in HSV (Hue, Saturation, Value) form with no alpha component.
     /// </summary>
+    /// <seealso cref="HSVA"/>
     public readonly struct HSV : IEquatable<HSV>
     {
         #region Fields

--- a/Assets/Scripts/Colour/HSVA.cs
+++ b/Assets/Scripts/Colour/HSVA.cs
@@ -9,6 +9,7 @@ namespace PAC.Colour
     /// <summary>
     /// A colour in HSV (Hue, Saturation, Value) form with an alpha component.
     /// </summary>
+    /// <seealso cref="HSV"/>
     public readonly struct HSVA : IEquatable<HSVA>
     {
         #region Fields

--- a/Assets/Scripts/Colour/RGB.cs
+++ b/Assets/Scripts/Colour/RGB.cs
@@ -12,6 +12,7 @@ namespace PAC.Colour
     /// <remarks>
     /// The RGB values are in the inclusive range <c>[0, 1]</c>.
     /// </remarks>
+    /// <seealso cref="Color"/>
     public readonly struct RGB : IEquatable<RGB>
     {
         #region Fields


### PR DESCRIPTION
# Summary

Adds `seealso` comments to `RGB`, `HSL`, `HSLA`, `HSV` and `HSVA`, and fixes the comment for `HSL.WithAlpha(float)` referring to `HSL` instead of `HSLA`.