### PR TITLE
Stop external types inheriting from abstract axis types

### DIFF
--- a/Assets/Scripts/Geometry/Axes/CardinalAxis.cs
+++ b/Assets/Scripts/Geometry/Axes/CardinalAxis.cs
@@ -3,7 +3,10 @@ namespace PAC.Geometry.Axes
     /// <summary>
     /// <see cref="HorizontalAxis"/> or <see cref="VerticalAxis"/>.
     /// </summary>
-    public abstract record CardinalAxis : CardinalOrdinalAxis { }
+    public abstract record CardinalAxis : CardinalOrdinalAxis
+    {
+        internal CardinalAxis() { } // don't allow external types to inherit from this
+    }
 
     /// <summary>
     /// The type of <see cref="CardinalAxis.Horizontal"/>.

--- a/Assets/Scripts/Geometry/Axes/CardinalOrdinalAxis.cs
+++ b/Assets/Scripts/Geometry/Axes/CardinalOrdinalAxis.cs
@@ -3,5 +3,8 @@ namespace PAC.Geometry.Axes
     /// <summary>
     /// Either a <see cref="CardinalAxis"/> or <see cref="OrdinalAxis"/>.
     /// </summary>
-    public abstract record CardinalOrdinalAxis { }
+    public abstract record CardinalOrdinalAxis
+    {
+        internal CardinalOrdinalAxis() { } // don't allow external types to inherit from this
+    }
 }

--- a/Assets/Scripts/Geometry/Axes/OrdinalAxis.cs
+++ b/Assets/Scripts/Geometry/Axes/OrdinalAxis.cs
@@ -3,7 +3,10 @@ namespace PAC.Geometry.Axes
     /// <summary>
     /// <see cref="Diagonal45Axis"/> or <see cref="Minus45Axis"/>.
     /// </summary>
-    public abstract record OrdinalAxis : CardinalOrdinalAxis { }
+    public abstract record OrdinalAxis : CardinalOrdinalAxis
+    {
+        internal OrdinalAxis() { } // don't allow external types to inherit from this
+    }
 
     /// <summary>
     /// The type of <see cref="OrdinalAxis.Diagonal45"/>.


### PR DESCRIPTION
# Summary

Add an internal constructor to `CardinalAxis`, `OrdinalAxis` and `CardinalOrdinalAxis` so that external types can't inherit from them. This is to emphasize the fact that in these classes there should only ever be the 4 axes that are defined currently.