### PR TITLE
Move `Texture2DExtensions.Blend()` methods into new `BlendModeExtensions` class

### DIFF
--- a/Assets/Scripts/Animation/AnimationManager.cs
+++ b/Assets/Scripts/Animation/AnimationManager.cs
@@ -356,11 +356,17 @@ namespace PAC.Animation
             }
             else if (currentFrameIndex > 0)
             {
-                onionSkin.sprite = Texture2DExtensions.Blend(onionSkinColour, fileManager.currentFile.Render(currentFrameIndex - 1), BlendMode.Multiply).ToSprite();
+                onionSkin.sprite = BlendMode.Multiply.Blend(
+                    onionSkinColour,
+                    fileManager.currentFile.Render(currentFrameIndex - 1)
+                    ).ToSprite();
             }
             else if (currentFrameIndex == 0 && playbackMode.selectedOption == "loop")
             {
-                onionSkin.sprite = Texture2DExtensions.Blend(onionSkinColour, fileManager.currentFile.Render(currentFrameIndex - 1), BlendMode.Multiply).ToSprite();
+                onionSkin.sprite = BlendMode.Multiply.Blend(
+                    onionSkinColour,
+                    fileManager.currentFile.Render(currentFrameIndex - 1)
+                    ).ToSprite();
             }
             else
             {

--- a/Assets/Scripts/Clipboard/Clipboard.cs
+++ b/Assets/Scripts/Clipboard/Clipboard.cs
@@ -49,7 +49,10 @@ namespace PAC.Clipboard
         {
             if (drawingArea.hasSelection)
             {
-                copiedTexture = layerManager.selectedLayer[animationManager.currentFrameIndex].texture.Blend(drawingArea.selectionMask, BlendMode.Multiply).ExtendCrop(drawingArea.selectionRect);
+                copiedTexture = BlendMode.Multiply.Blend(
+                    layerManager.selectedLayer[animationManager.currentFrameIndex].texture,
+                    drawingArea.selectionMask
+                    ).ExtendCrop(drawingArea.selectionRect);
                 copiedTexturePos = drawingArea.selectionRect.bottomLeft;
 
                 Debug.Log("Copied.");
@@ -66,9 +69,9 @@ namespace PAC.Clipboard
                 bottomLeft = IntVector2.Max(bottomLeft, IntVector2.zero);
 
                 layerManager.AddLayer(
-                    copiedTexture.Blend(
+                    BlendMode.Normal.Blend(
+                        copiedTexture,
                         Texture2DCreator.Transparent(fileManager.currentFile.width, fileManager.currentFile.height),
-                        BlendMode.Normal,
                         bottomLeft
                         )
                     );

--- a/Assets/Scripts/Colour/Compositing/BlendMode.cs
+++ b/Assets/Scripts/Colour/Compositing/BlendMode.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Reflection;
 
+using PAC.DataStructures;
+using PAC.Extensions;
 using PAC.Json;
 
 using UnityEngine;
@@ -70,6 +72,66 @@ namespace PAC.Colour.Compositing
                 ).WithAlpha(top.a),
                 bottom
                 );
+
+        /// <summary>
+        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
+        /// of <paramref name="topTexture"/> on the bottom-left corner of <paramref name="bottomTexture"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
+        /// </remarks>
+        public Texture2D Blend(Texture2D topTexture, Texture2D bottomTexture) => Blend(topTexture, bottomTexture, (0, 0));
+        /// <summary>
+        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
+        /// of <paramref name="topTexture"/> at the coordinates <paramref name="topTextureOffset"/> on <paramref name="bottomTexture"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
+        /// </remarks>
+        public Texture2D Blend(Texture2D topTexture, Texture2D bottomTexture, IntVector2 topTextureOffset)
+        {
+            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
+
+            for (int x = 0; x < bottomTexture.width; x++)
+            {
+                for (int y = 0; y < bottomTexture.height; y++)
+                {
+                    if (blended.ContainsPixel(x - topTextureOffset.x, y - topTextureOffset.y))
+                    {
+                        Color topColour = topTexture.GetPixel(x - topTextureOffset.x, y - topTextureOffset.y);
+                        Color bottomColour = bottomTexture.GetPixel(x, y);
+                        blended.SetPixel(x, y, Blend(topColour, bottomColour));
+                    }
+                    else
+                    {
+                        blended.SetPixel(x, y, bottomTexture.GetPixel(x, y));
+                    }
+                }
+            }
+
+            return blended.Applied();
+        }
+        /// <summary>
+        /// Blends <paramref name="topColour"/> onto each pixel of a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
+        /// </remarks>
+        public Texture2D Blend(Color topColour, Texture2D bottomTexture)
+        {
+            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
+
+            for (int x = 0; x < bottomTexture.width; x++)
+            {
+                for (int y = 0; y < bottomTexture.height; y++)
+                {
+                    Color bottomColour = bottomTexture.GetPixel(x, y);
+                    blended.SetPixel(x, y, Blend(topColour, bottomColour));
+                }
+            }
+
+            return blended.Applied();
+        }
 
         public override string ToString() => name;
         #endregion

--- a/Assets/Scripts/Colour/Compositing/BlendMode.cs
+++ b/Assets/Scripts/Colour/Compositing/BlendMode.cs
@@ -73,66 +73,6 @@ namespace PAC.Colour.Compositing
                 bottom
                 );
 
-        /// <summary>
-        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
-        /// of <paramref name="topTexture"/> on the bottom-left corner of <paramref name="bottomTexture"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
-        /// </remarks>
-        public Texture2D Blend(Texture2D topTexture, Texture2D bottomTexture) => Blend(topTexture, bottomTexture, (0, 0));
-        /// <summary>
-        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
-        /// of <paramref name="topTexture"/> at the coordinates <paramref name="topTextureOffset"/> on <paramref name="bottomTexture"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
-        /// </remarks>
-        public Texture2D Blend(Texture2D topTexture, Texture2D bottomTexture, IntVector2 topTextureOffset)
-        {
-            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
-
-            for (int x = 0; x < bottomTexture.width; x++)
-            {
-                for (int y = 0; y < bottomTexture.height; y++)
-                {
-                    if (blended.ContainsPixel(x - topTextureOffset.x, y - topTextureOffset.y))
-                    {
-                        Color topColour = topTexture.GetPixel(x - topTextureOffset.x, y - topTextureOffset.y);
-                        Color bottomColour = bottomTexture.GetPixel(x, y);
-                        blended.SetPixel(x, y, Blend(topColour, bottomColour));
-                    }
-                    else
-                    {
-                        blended.SetPixel(x, y, bottomTexture.GetPixel(x, y));
-                    }
-                }
-            }
-
-            return blended.Applied();
-        }
-        /// <summary>
-        /// Blends <paramref name="topColour"/> onto each pixel of a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
-        /// </remarks>
-        public Texture2D Blend(Color topColour, Texture2D bottomTexture)
-        {
-            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
-
-            for (int x = 0; x < bottomTexture.width; x++)
-            {
-                for (int y = 0; y < bottomTexture.height; y++)
-                {
-                    Color bottomColour = bottomTexture.GetPixel(x, y);
-                    blended.SetPixel(x, y, Blend(topColour, bottomColour));
-                }
-            }
-
-            return blended.Applied();
-        }
-
         public override string ToString() => name;
         #endregion
 
@@ -326,5 +266,74 @@ namespace PAC.Colour.Compositing
             }
         }
         #endregion
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="BlendMode"/>.
+    /// </summary>
+    /// <remarks>
+    /// These methods aren't in the <see cref="BlendMode"/> type itself because they don't directly relate to the purpose of <see cref="BlendMode"/>.
+    /// </remarks>
+    public static class BlendModeExtensions
+    {
+        /// <summary>
+        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
+        /// of <paramref name="topTexture"/> on the bottom-left corner of <paramref name="bottomTexture"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
+        /// </remarks>
+        public static Texture2D Blend(this BlendMode blendMode, Texture2D topTexture, Texture2D bottomTexture) => Blend(blendMode, topTexture, bottomTexture, (0, 0));
+        /// <summary>
+        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
+        /// of <paramref name="topTexture"/> at the coordinates <paramref name="topTextureOffset"/> on <paramref name="bottomTexture"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
+        /// </remarks>
+        public static Texture2D Blend(this BlendMode blendMode, Texture2D topTexture, Texture2D bottomTexture, IntVector2 topTextureOffset)
+        {
+            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
+
+            for (int x = 0; x < bottomTexture.width; x++)
+            {
+                for (int y = 0; y < bottomTexture.height; y++)
+                {
+                    if (blended.ContainsPixel(x - topTextureOffset.x, y - topTextureOffset.y))
+                    {
+                        Color topColour = topTexture.GetPixel(x - topTextureOffset.x, y - topTextureOffset.y);
+                        Color bottomColour = bottomTexture.GetPixel(x, y);
+                        blended.SetPixel(x, y, blendMode.Blend(topColour, bottomColour));
+                    }
+                    else
+                    {
+                        blended.SetPixel(x, y, bottomTexture.GetPixel(x, y));
+                    }
+                }
+            }
+
+            return blended.Applied();
+        }
+        /// <summary>
+        /// Blends <paramref name="topColour"/> onto each pixel of a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
+        /// </remarks>
+        public static Texture2D Blend(this BlendMode blendMode, Color topColour, Texture2D bottomTexture)
+        {
+            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
+
+            for (int x = 0; x < bottomTexture.width; x++)
+            {
+                for (int y = 0; y < bottomTexture.height; y++)
+                {
+                    Color bottomColour = bottomTexture.GetPixel(x, y);
+                    blended.SetPixel(x, y, blendMode.Blend(topColour, bottomColour));
+                }
+            }
+
+            return blended.Applied();
+        }
     }
 }

--- a/Assets/Scripts/Drawing/DrawingArea.cs
+++ b/Assets/Scripts/Drawing/DrawingArea.cs
@@ -1072,18 +1072,18 @@ namespace PAC.Drawing
             {
                 Texture2D bottomLayers = file.RenderLayersBelow(selectedLayerIndex, currentFrameIndex);
                 Texture2D topLayers = file.RenderLayersAbove(selectedLayerIndex, currentFrameIndex);
-                drawingSprRen.sprite = topLayers.Blend(
-                    selectionTexture.Blend(bottomLayers, BlendMode.Normal, mouseCoords - mouseDragPoints[0]),
-                    BlendMode.Normal
+                drawingSprRen.sprite = BlendMode.Normal.Blend(
+                    topLayers,
+                    BlendMode.Normal.Blend(selectionTexture, bottomLayers, mouseCoords - mouseDragPoints[0])
                     ).ToSprite();
             }
             else
             {
                 Texture2D bottomLayers = file.RenderLayersBelow(selectedLayerIndex, currentFrameIndex);
                 Texture2D topLayers = file.RenderLayersAbove(selectedLayerIndex, currentFrameIndex);
-                drawingSprRen.sprite = topLayers.Blend(
-                    selectionTexture.Blend(bottomLayers, BlendMode.Normal, mouseCoords - mouseDragPoints[0]),
-                    BlendMode.Normal
+                drawingSprRen.sprite = BlendMode.Normal.Blend(
+                    topLayers,
+                    BlendMode.Normal.Blend(selectionTexture, bottomLayers, mouseCoords - mouseDragPoints[0])
                     ).ToSprite();
             }
         }
@@ -1093,7 +1093,7 @@ namespace PAC.Drawing
             Texture2D tex = shape.ToTexture(Config.Colours.mask, file.rect);
             if (erase)
             {
-                selectionMask = selectionMask.Blend(tex, BlendMode.Subtract);
+                selectionMask = BlendMode.Subtract.Blend(selectionMask, tex);
             }
         }
 
@@ -1115,18 +1115,27 @@ namespace PAC.Drawing
             {
                 if (selectionMask.GetPixel(pixel.x, pixel.y).a != 0f)
                 {
-                    selectionMask = selectionMask.Blend(GetMagicWandMask(selectedLayer[animationManager.currentFrameIndex].texture, pixel), BlendMode.Subtract);
+                    selectionMask = BlendMode.Subtract.Blend(
+                        selectionMask,
+                        GetMagicWandMask(selectedLayer[animationManager.currentFrameIndex].texture, pixel)
+                        );
                 }
                 else
                 {
-                    selectionMask = selectionMask.Blend(GetMagicWandMask(selectionMask, pixel), BlendMode.Subtract);
+                    selectionMask = BlendMode.Subtract.Blend(
+                        selectionMask,
+                        GetMagicWandMask(selectionMask, pixel)
+                        );
                 }
             }
             else
             {
                 if (addToExistingSelection)
                 {
-                    selectionMask = selectionMask.Blend(GetMagicWandMask(selectedLayer[animationManager.currentFrameIndex].texture, pixel), BlendMode.Normal);
+                    selectionMask = BlendMode.Normal.Blend(
+                        selectionMask,
+                        GetMagicWandMask(selectedLayer[animationManager.currentFrameIndex].texture, pixel)
+                        );
                 }
                 else
                 {

--- a/Assets/Scripts/Extensions/Texture2DExtensions.cs
+++ b/Assets/Scripts/Extensions/Texture2DExtensions.cs
@@ -259,66 +259,6 @@ namespace PAC.Extensions
         }
 
         /// <summary>
-        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
-        /// of <paramref name="topTexture"/> on the bottom-left corner of <paramref name="bottomTexture"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
-        /// </remarks>
-        public static Texture2D Blend(this Texture2D topTexture, Texture2D bottomTexture, BlendMode blendMode) => Blend(topTexture, bottomTexture, blendMode, (0, 0));
-        /// <summary>
-        /// Blends a deep copy of <paramref name="topTexture"/> onto a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>, placing the bottom-left corner
-        /// of <paramref name="topTexture"/> at the coordinates <paramref name="topTextureOffset"/> on <paramref name="bottomTexture"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
-        /// </remarks>
-        public static Texture2D Blend(this Texture2D topTexture, Texture2D bottomTexture, BlendMode blendMode, IntVector2 topTextureOffset)
-        {
-            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
-
-            for (int x = 0; x < bottomTexture.width; x++)
-            {
-                for (int y = 0; y < bottomTexture.height; y++)
-                {
-                    if (blended.ContainsPixel(x - topTextureOffset.x, y - topTextureOffset.y))
-                    {
-                        Color topColour = topTexture.GetPixel(x - topTextureOffset.x, y - topTextureOffset.y);
-                        Color bottomColour = bottomTexture.GetPixel(x, y);
-                        blended.SetPixel(x, y, blendMode.Blend(topColour, bottomColour));
-                    }
-                    else
-                    {
-                        blended.SetPixel(x, y, bottomTexture.GetPixel(x, y));
-                    }
-                }
-            }
-
-            return blended.Applied();
-        }
-        /// <summary>
-        /// Blends <paramref name="topColour"/> onto each pixel of a deep copy of <paramref name="bottomTexture"/> using the given <see cref="BlendMode"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calls <see cref="Texture2D.Apply()"/> on the returned <see cref="Texture2D"/>.
-        /// </remarks>
-        public static Texture2D Blend(Color topColour, Texture2D bottomTexture, BlendMode blendMode)
-        {
-            Texture2D blended = new Texture2D(bottomTexture.width, bottomTexture.height);
-
-            for (int x = 0; x < bottomTexture.width; x++)
-            {
-                for (int y = 0; y < bottomTexture.height; y++)
-                {
-                    Color bottomColour = bottomTexture.GetPixel(x, y);
-                    blended.SetPixel(x, y, blendMode.Blend(topColour, bottomColour));
-                }
-            }
-
-            return blended.Applied();
-        }
-
-        /// <summary>
         /// Calls <see cref="Scale(Texture2D, float, float)"/> with both scale factors equal to <paramref name="scaleFactor"/>.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="scaleFactor"/> is &lt;= 0.</exception>

--- a/Assets/Scripts/Layers/LayerManager.cs
+++ b/Assets/Scripts/Layers/LayerManager.cs
@@ -267,7 +267,7 @@ namespace PAC.Layers
 
                     for (int i = selectedLayers.Length - 2; i >= 0; i--)
                     {
-                        tex = selectedLayers[i][keyFrame].texture.Blend(tex, BlendMode.Normal);
+                        tex = BlendMode.Normal.Blend(selectedLayers[i][keyFrame].texture, tex);
                     }
                     ((NormalLayer)selectedLayers[^1]).SetTexture(keyFrame, tex, AnimFrameRefMode.NewKeyFrame);
                 }

--- a/Assets/Scripts/Layers/NormalLayer.cs
+++ b/Assets/Scripts/Layers/NormalLayer.cs
@@ -91,7 +91,11 @@ namespace PAC.Layers
                 AddKeyFrame(frame);
             }
 
-            GetKeyFrame(frame).texture = overlayTex.Blend(GetKeyFrame(frame).texture, BlendMode.Normal, offset);
+            GetKeyFrame(frame).texture = BlendMode.Normal.Blend(
+                overlayTex,
+                GetKeyFrame(frame).texture,
+                offset
+                );
             onPixelsChanged.Invoke(rect, new int[] { GetKeyFrame(frame).frame });
         }
         /// <summary>

--- a/Assets/Scripts/UI/DialogBoxManager.cs
+++ b/Assets/Scripts/UI/DialogBoxManager.cs
@@ -368,12 +368,11 @@ namespace PAC.UI
 
             Texture2D render = fileManager.currentFile.Render(animationManager.currentFrameIndex).Applied();
 
-            extendCropPreview.sprite = render
-                .ExtendCrop(new Texture2DExtensions.ExtendCropOptions { left = left, right = right, top = up, bottom = down })
-                .Scale(2)
-                .Blend(
-                    Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width + left + right, fileManager.currentFile.height + up + down),
-                    BlendMode.Normal
+            extendCropPreview.sprite = BlendMode.Normal.Blend(
+                render
+                    .ExtendCrop(new Texture2DExtensions.ExtendCropOptions { left = left, right = right, top = up, bottom = down })
+                    .Scale(2),
+                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width + left + right, fileManager.currentFile.height + up + down)
                 )
                 .ToSprite();
         }
@@ -448,9 +447,9 @@ namespace PAC.UI
 
             Texture2D render = fileManager.currentFile.Render(animationManager.currentFrameIndex).Applied();
 
-            scalePreview.sprite = render.Scale(2 * width, 2 * height).Blend(
-                Texture2DCreator.TransparentCheckerboardBackground(width, height),
-                BlendMode.Normal
+            scalePreview.sprite = BlendMode.Normal.Blend(
+                render.Scale(2 * width, 2 * height),
+                Texture2DCreator.TransparentCheckerboardBackground(width, height)
                 ).ToSprite();
         }
 
@@ -505,9 +504,9 @@ namespace PAC.UI
 
             Texture2D render = fileManager.currentFile.Render(animationManager.currentFrameIndex).Applied();
 
-            gridPreview.sprite = render.Scale(2).Blend(
-                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height),
-                BlendMode.Normal
+            gridPreview.sprite = BlendMode.Normal.Blend(
+                render.Scale(2),
+                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height)
                 ).ToSprite();
 
             gridPreviewGridManager.SetOnOffNoDisplayUpdate(on);
@@ -584,9 +583,9 @@ namespace PAC.UI
 
             Texture2D render = fileCopy.Render(animationManager.currentFrameIndex).Applied();
 
-            outlinePreview.sprite = render.Scale(2).Blend(
-                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height),
-                BlendMode.Normal
+            outlinePreview.sprite = BlendMode.Normal.Blend(
+                render.Scale(2),
+                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height)
                 ).ToSprite();
         }
 
@@ -639,9 +638,9 @@ namespace PAC.UI
 
             Texture2D render = fileCopy.Render(animationManager.currentFrameIndex).Applied();
 
-            replaceColourPreview.sprite = render.Scale(2).Blend(
-                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height),
-                BlendMode.Normal
+            replaceColourPreview.sprite = BlendMode.Normal.Blend(
+                render.Scale(2),
+                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height)
                 ).ToSprite();
         }
 
@@ -699,9 +698,9 @@ namespace PAC.UI
 
         public void UpdateImportPACPreview()
         {
-            importPACPreview.sprite = importPACFile.RenderLayers(importPACLayersToggleGroup.selectedIndices, animationManager.currentFrameIndex).Scale(2).Blend(
-                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height),
-                BlendMode.Normal
+            importPACPreview.sprite = BlendMode.Normal.Blend(
+                importPACFile.RenderLayers(importPACLayersToggleGroup.selectedIndices, animationManager.currentFrameIndex).Scale(2),
+                Texture2DCreator.TransparentCheckerboardBackground(fileManager.currentFile.width, fileManager.currentFile.height)
                 ).ToSprite();
         }
 


### PR DESCRIPTION
# Summary

Moves the `Blend` methods in `Texture2DExtensions` into a new `BlendModeExtensions` class.

They aren't moved into `BlendMode` itself because they aren't directly related to the purpose of `BlendMode`, which is just to define how two colours get blended. I think the separation makes the code clearer.