### PR TITLE
Refactor `IntRange.BoundingRange(IEnumerable<int>)` into extension method

### DIFF
--- a/Assets/Scripts/Data Structures/Extensions/IntRangeExtensions.cs
+++ b/Assets/Scripts/Data Structures/Extensions/IntRangeExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using PAC.Extensions.System.Collections;
+
 namespace PAC.DataStructures.Extensions
 {
     /// <summary>
@@ -30,6 +32,30 @@ namespace PAC.DataStructures.Extensions
             {
                 yield return list[index];
             }
+        }
+
+        /// <summary>
+        /// Returns the smallest <see cref="IntRange"/> containing all the given values.
+        /// </summary>
+        /// <returns>
+        /// The smallest <see cref="IntRange"/> containing all the given values. It will be expressed with both boundaries inclusive, unless the sequence of values is empty, in which case it
+        /// will be expressed with both boundaries exclusive.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="integers"/> is null.</exception>
+        public static IntRange Range(this IEnumerable<int> integers)
+        {
+            if (integers is null)
+            {
+                throw new ArgumentNullException(nameof(integers), $"Cannot perform {nameof(Range)}() on null.");
+            }
+
+            if (integers.None())
+            {
+                return IntRange.Empty;
+            }
+
+            (int min, int max) = integers.MinAndMax();
+            return IntRange.InclIncl(min, max);
         }
     }
 }

--- a/Assets/Scripts/Data Structures/IntRange.cs
+++ b/Assets/Scripts/Data Structures/IntRange.cs
@@ -738,7 +738,7 @@ namespace PAC.DataStructures
         /// </para>
         /// <para>
         /// <example>
-        /// For example, the range from -1 (inclusive) to 5 (exclusive) will be respresented as <c>"[-1, 5)"</c>.
+        /// For example, the range from -1 (inclusive) to 5 (exclusive) will be represented as <c>"[-1, 5)"</c>.
         /// </example>
         /// </para>
         /// </summary>

--- a/Assets/Scripts/Data Structures/IntRange.cs
+++ b/Assets/Scripts/Data Structures/IntRange.cs
@@ -653,30 +653,6 @@ namespace PAC.DataStructures
         /// <exception cref="InvalidOperationException">The range is empty.</exception>
         /// <seealso cref="Math.Clamp(int, int, int)"/>
         public int Clamp(int n) => isEmpty ? throw new InvalidOperationException("The range is empty.") : Math.Clamp(n, minElement, maxElement);
-
-        /// <summary>
-        /// Returns the smallest range containing all the given values.
-        /// </summary>
-        /// <returns>
-        /// The smallest range containing all the given values. It will be expressed with both boundaries inclusive, unless the sequence of values is empty, in which case it will be expressed with
-        /// both boundaries exclusive.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="integers"/> is null.</exception>
-        public static IntRange BoundingRange(IEnumerable<int> integers)
-        {
-            if (integers is null)
-            {
-                throw new ArgumentNullException(nameof(integers), $"Cannot perform {nameof(BoundingRange)}() on null.");
-            }
-
-            if (integers.None())
-            {
-                return Empty;
-            }
-
-            (int min, int max) = integers.MinAndMax();
-            return InclIncl(min, max);
-        }
         #endregion
 
         #region Enumerator

--- a/Assets/Tests/Data Structures/Extensions/IntRangeExtensions_Tests.cs
+++ b/Assets/Tests/Data Structures/Extensions/IntRangeExtensions_Tests.cs
@@ -85,8 +85,8 @@ namespace PAC.Tests.DataStructures.Extensions
                 {
                     Assert.True(boundingRange.Contains(value), $"Failed with {testCase} and {value}.");
                 }
-                Assert.False(boundingRange.Contains(((IEnumerable<int>)boundingRange).Min() - 1), $"Failed with {testCase}.");
-                Assert.False(boundingRange.Contains(((IEnumerable<int>)boundingRange).Max() + 1), $"Failed with {testCase}.");
+                Assert.False(boundingRange.Contains(Enumerable.Min(boundingRange) - 1), $"Failed with {testCase}.");
+                Assert.False(boundingRange.Contains(Enumerable.Max(boundingRange) + 1), $"Failed with {testCase}.");
 
                 Assert.True(boundingRange.isInclIncl, $"Failed with {testCase}");
             }

--- a/Assets/Tests/Data Structures/Extensions/IntRangeExtensions_Tests.cs
+++ b/Assets/Tests/Data Structures/Extensions/IntRangeExtensions_Tests.cs
@@ -45,5 +45,53 @@ namespace PAC.Tests.DataStructures.Extensions
             Assert.Throws<ArgumentOutOfRangeException>(() => IntRangeExtensions.GetRange(list, IntRange.InclIncl(0, list.Count)).ToArray());
             Assert.Throws<ArgumentOutOfRangeException>(() => IntRangeExtensions.GetRange(list, IntRange.InclIncl(0, -1)).ToArray());
         }
+
+        /// <summary>
+        /// Tests <see cref="IntRangeExtensions.Range(IEnumerable{int})"/>.
+        /// </summary>
+        [Test]
+        [Category("Data Structures")]
+        public void Range()
+        {
+            Random random = new Random(0);
+
+            const int maxTestCaseLength = 20;
+            const int numTestCasesPerLength = 1_000;
+
+            List<int[]> testCases = new List<int[]>();
+            for (int length = 1; length <= maxTestCaseLength; length++)
+            {
+                for (int i = 0; i < numTestCasesPerLength; i++)
+                {
+                    int[] testCase = new int[length];
+                    for (int j = 0; j < length; j++)
+                    {
+                        testCase[j] = random.Next(-100, 100);
+                    }
+                    testCases.Add(testCase);
+                }
+            }
+
+            /////
+
+            Assert.True(IntRangeExtensions.Range(new int[] { }).isEmpty);
+            Assert.True(IntRangeExtensions.Range(new int[] { }).isExclExcl);
+
+            foreach (int[] testCase in testCases)
+            {
+                IntRange boundingRange = IntRangeExtensions.Range(testCase);
+
+                foreach (int value in testCase)
+                {
+                    Assert.True(boundingRange.Contains(value), $"Failed with {testCase} and {value}.");
+                }
+                Assert.False(boundingRange.Contains(((IEnumerable<int>)boundingRange).Min() - 1), $"Failed with {testCase}.");
+                Assert.False(boundingRange.Contains(((IEnumerable<int>)boundingRange).Max() + 1), $"Failed with {testCase}.");
+
+                Assert.True(boundingRange.isInclIncl, $"Failed with {testCase}");
+            }
+
+            Assert.Throws<ArgumentNullException>(() => IntRangeExtensions.Range(null));
+        }
     }
 }

--- a/Assets/Tests/Data Structures/IntRange_Tests.cs
+++ b/Assets/Tests/Data Structures/IntRange_Tests.cs
@@ -389,51 +389,6 @@ namespace PAC.Tests.DataStructures
                 }
             }
         }
-
-        [Test]
-        [Category("Data Structures")]
-        public void BoundingRange()
-        {
-            Random random = new Random(0);
-
-            const int maxTestCaseLength = 20;
-            const int numTestCasesPerLength = 1_000;
-
-            List<int[]> testCases = new List<int[]>();
-            for (int length = 1; length <= maxTestCaseLength; length++)
-            {
-                for (int i = 0; i < numTestCasesPerLength; i++)
-                {
-                    int[] testCase = new int[length];
-                    for (int j = 0; j < length; j++)
-                    {
-                        testCase[j] = random.Next(-100, 100);
-                    }
-                    testCases.Add(testCase);
-                }
-            }
-
-            /////
-
-            Assert.True(IntRange.BoundingRange(new int[] { }).isEmpty);
-            Assert.True(IntRange.BoundingRange(new int[] { }).isExclExcl);
-
-            foreach (int[] testCase in testCases)
-            {
-                IntRange boundingRange = IntRange.BoundingRange(testCase);
-
-                foreach (int value in testCase)
-                {
-                    Assert.True(boundingRange.Contains(value), $"Failed with {testCase} and {value}.");
-                }
-                Assert.False(boundingRange.Contains(((IEnumerable<int>)boundingRange).Min() - 1), $"Failed with {testCase}.");
-                Assert.False(boundingRange.Contains(((IEnumerable<int>)boundingRange).Max() + 1), $"Failed with {testCase}.");
-
-                Assert.True(boundingRange.isInclIncl, $"Failed with {testCase}");
-            }
-
-            Assert.Throws<ArgumentNullException>(() => IntRange.BoundingRange(null));
-        }
         #endregion
 
         #region Tests: Enumerator


### PR DESCRIPTION
# Summary

Refactors `IntRange.BoundingRange(IEnumerable<int>)` to be an extension method `Range` on `IEnumerable<int>`.