### PR TITLE
Make `IntRect.RandomSubRect(Random)` have a uniform distribution

### DIFF
--- a/Assets/Scripts/Data Structures/IntRange.cs
+++ b/Assets/Scripts/Data Structures/IntRange.cs
@@ -655,6 +655,34 @@ namespace PAC.DataStructures
         public int Clamp(int n) => isEmpty ? throw new InvalidOperationException("The range is empty.") : Math.Clamp(n, minElement, maxElement);
         #endregion
 
+        #region Random
+        /// <summary>
+        /// Returns an ordered pair <c>(x, y)</c>, with <c>x</c> and <c>y</c> in this <see cref="IntRange"/> and with <c>x != y</c>, uniformly at random from all such ordered pairs.
+        /// </summary>
+        /// <remarks>Note that, e.g., <c>(1, 2)</c> and <c>(2, 1)</c> are different ordered pairs so could both be returned.</remarks>
+        /// <exception cref="InvalidOperationException">The range has &lt;= 1 element.</exception>
+        public (int, int) RandomDistinctOrderedPair(Random random)
+        {
+            if (isEmpty)
+            {
+                throw new InvalidOperationException("The range is empty.");
+            }
+            if (Count == 1)
+            {
+                throw new InvalidOperationException("There is only one element in the range.");
+            }
+
+            int value1 = random.Next(minElement, maxElement + 1);
+            int value2 = random.Next(minElement, maxElement);
+            if (value2 >= value1)
+            {
+                value2++;
+            }
+
+            return (value1, value2);
+        }
+        #endregion
+
         #region Enumerator
         /// <summary>
         /// Indexes the elements of the range from <see cref="startElement"/> to <see cref="endElement"/>.

--- a/Assets/Scripts/Geometry/IntRect.cs
+++ b/Assets/Scripts/Geometry/IntRect.cs
@@ -503,9 +503,19 @@ namespace PAC.Geometry
         /// </summary>
         public IntVector2 RandomPoint(System.Random random) => new IntVector2(random.Next(minX, maxX + 1), random.Next(minY, maxY + 1));
         /// <summary>
-        /// Returns the rect defined by two independently uniformly randomly generated points within the rect.
+        /// Returns a rect uniformly at random from the set of all (weak) sub-rects.
         /// </summary>
-        public IntRect RandomSubRect(System.Random random) => new IntRect(RandomPoint(random), RandomPoint(random));
+        public IntRect RandomSubRect(System.Random random)
+        {
+            // We pick the two vertical edges of the rect, taking an int as referring to the left edge of a grid square
+            (int verticalEdge1, int verticalEdge2) = xRange.Extend(0, 1).RandomDistinctOrderedPair(random);
+            // Similarly, we pick the horizontal edges, taking an int as referring to the bottom edge of a grid square
+            (int horizontalEdge1, int horizontalEdge2) = yRange.Extend(0, 1).RandomDistinctOrderedPair(random);
+
+            IntVector2 bottomLeft = new IntVector2(Math.Min(verticalEdge1, verticalEdge2), Math.Min(horizontalEdge1, horizontalEdge2));
+            IntVector2 topRight = new IntVector2(Math.Max(verticalEdge1, verticalEdge2) - 1, Math.Max(horizontalEdge1, horizontalEdge2) - 1);
+            return new IntRect(bottomLeft, topRight);
+        }
         #endregion
 
         #region Enumerator

--- a/Assets/Tests/Data Structures/IntRange_Tests.cs
+++ b/Assets/Tests/Data Structures/IntRange_Tests.cs
@@ -391,6 +391,50 @@ namespace PAC.Tests.DataStructures
         }
         #endregion
 
+        #region Random
+        /// <summary>
+        /// Tests <see cref="IntRange.RandomDistinctOrderedPair(Random)"/>.
+        /// </summary>
+        [Test]
+        [Category("Data Structures"), Category("Random")]
+        public void RandomDistinctOrderedPair()
+        {
+            for (int seed = 0; seed <= 2; seed++)
+            {
+                Random random = new Random(seed);
+
+                foreach (IntRange range in testCases.Take(100))
+                {
+                    if (range.Count <= 1)
+                    {
+                        Assert.Throws<InvalidOperationException>(() => range.RandomDistinctOrderedPair(random), $"Failed with {range}.");
+                        continue;
+                    }
+
+                    Dictionary<(int, int), int> counts = new Dictionary<(int, int), int>();
+
+                    const int numIterations = 10_000;
+                    for (int i = 0; i < numIterations; i++)
+                    {
+                        (int x, int y) randomOrderedPair = range.RandomDistinctOrderedPair(random);
+                        Assert.True(range.Contains(randomOrderedPair.x), $"Failed with {range} and {randomOrderedPair}.");
+                        Assert.True(range.Contains(randomOrderedPair.y), $"Failed with {range} and {randomOrderedPair}.");
+
+                        counts[randomOrderedPair] = counts.GetValueOrDefault(randomOrderedPair, 0) + 1;
+                    }
+
+                    int numDistinctOrderedPairs = range.Count * (range.Count - 1);
+                    float expected = 1f / numDistinctOrderedPairs;
+                    float tolerance = 0.02f;
+                    foreach ((int, int) orderedPair in counts.Keys)
+                    {
+                        Assert.AreEqual(expected, counts.GetValueOrDefault(orderedPair, 0) / (float)numIterations, tolerance, $"Failed with {range} and {orderedPair}.");
+                    }
+                }
+            }
+        }
+        #endregion
+
         #region Tests: Enumerator
         [Test]
         [Category("Data Structures")]

--- a/Assets/Tests/Geometry/IntRect_Tests.cs
+++ b/Assets/Tests/Geometry/IntRect_Tests.cs
@@ -283,66 +283,39 @@ namespace PAC.Tests.Geometry
         }
 
         /// <summary>
-        /// Tests <see cref="IntRect.RandomSubRect(Random)"/> is indeed a subrect of the rect.
+        /// Tests <see cref="IntRect.RandomSubRect(Random)"/>.
         /// </summary>
         [Test]
         [Category("Data Structures"), Category("Random")]
-        public void RandomSubRect_IsSubRect()
+        public void RandomSubRect()
         {
             for (int seed = 0; seed <= 2; seed++)
             {
                 Random random = new Random(seed);
 
-                foreach (IntVector2 bottomLeft in new IntRect(new IntVector2(-1, -1), IntVector2.zero))
+                foreach (IntVector2 bottomLeft in new IntRect((-1, -1), (0, 0)))
                 {
-                    foreach (IntVector2 topRight in bottomLeft + new IntRect(IntVector2.zero, new IntVector2(2, 3)))
+                    foreach (IntVector2 topRight in bottomLeft + new IntRect((0, 0), (2, 3)))
                     {
                         IntRect rect = new IntRect(bottomLeft, topRight);
 
-                        for (int i = 0; i < 10_000; i++)
+                        Dictionary<IntRect, int> counts = new Dictionary<IntRect, int>();
+
+                        const int numIterations = 10_000;
+                        for (int i = 0; i < numIterations; i++)
                         {
                             IntRect randomSubRect = rect.RandomSubRect(random);
-                            Assert.True(randomSubRect.ToHashSet().IsSubsetOf(rect), $"Failed with {rect} and {randomSubRect}.");
-                        }
-                    }
-                }
-            }
-        }
+                            Assert.True(randomSubRect.IsSubsetOf(rect), $"Failed with {rect} and {randomSubRect}.");
 
-        /// <summary>
-        /// Tests that <see cref="IntRect.RandomSubRect(Random)"/> is not always a single point.
-        /// </summary>
-        [Test]
-        [Category("Data Structures"), Category("Random")]
-        public void RandomSubRect_IsNotAlwaysSinglePoint()
-        {
-            for (int seed = 0; seed <= 2; seed++)
-            {
-                Random random = new Random(seed);
-
-                foreach (IntVector2 bottomLeft in new IntRect(new IntVector2(-1, -1), IntVector2.zero))
-                {
-                    foreach (IntVector2 topRight in bottomLeft + new IntRect(IntVector2.zero, new IntVector2(2, 3)))
-                    {
-                        IntRect rect = new IntRect(bottomLeft, topRight);
-                        if (rect.Count == 1)
-                        {
-                            continue;
+                            counts[randomSubRect] = counts.GetValueOrDefault(randomSubRect, 0) + 1;
                         }
 
-                        bool passed = false;
-                        for (int i = 0; i < 10_000; i++)
+                        int numSubRects = (rect.width * (rect.width + 1)) / 2 * (rect.height * (rect.height + 1)) / 2;
+                        float expected = 1f / numSubRects;
+                        float tolerance = 0.02f;
+                        foreach (IntRect subRect in counts.Keys)
                         {
-                            IntRect randomSubRect = rect.RandomSubRect(random);
-                            if (randomSubRect.Count > 1)
-                            {
-                                passed = true;
-                            }
-                        }
-
-                        if (!passed)
-                        {
-                            Assert.Fail($"Failed with {rect}.");
+                            Assert.AreEqual(expected, counts.GetValueOrDefault(subRect, 0) / (float)numIterations, tolerance, $"Failed with {rect} and {subRect}.");
                         }
                     }
                 }


### PR DESCRIPTION
# Summary

Makes `IntRect.RandomSubRect(Random)` have a uniform distribution.

Previously it just picked two points  uniformly and used them as opposite corners, which doesn't give a uniform distribution for the rect they form (as e.g. a 1x1 sub-rect has only 1 pair of points that leads to it whereas a 2x2 has 4). The method previously didn't claim to have a uniform distribution, but I think it's better to make it uniform.